### PR TITLE
Step 4: Use markdown roxygen format, add crosslinks to `?linters`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -103,3 +103,4 @@ Collate:
     'unneeded_concatenation_linter.R'
     'with_id.R'
     'zzz.R'
+Roxygen: list(markdown = TRUE)

--- a/R/T_and_F_symbol_linter.R
+++ b/R/T_and_F_symbol_linter.R
@@ -1,8 +1,9 @@
-#' \code{T} and \code{F} symbol linter
+#' `T` and `F` symbol linter
 #'
-#' Avoid the symbols \code{T} and \code{F} (for \code{TRUE} and \code{FALSE}).
+#' Avoid the symbols `T` and `F` (for `TRUE` and `FALSE`).
 #'
 #' @evalRd rd_tags("T_and_F_symbol_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 T_and_F_symbol_linter <- function() { # nolint: object_name_linter.
   Linter(function(source_file) {

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -7,13 +7,13 @@ NULL
 #' @name linters
 #'
 #' @description A variety of linters is available in \pkg{lintr}. The most popular ones are readily
-#' accessible through \code{\link{default_linters}}, though there are additional ones you may want
+#' accessible through [default_linters()], though there are additional ones you may want
 #' to use.
 #'
-#' Within a \code{\link{lint}} function call, the linters in use are initialized with the provided
-#' arguments and fed with the source file (provided by \code{\link{get_source_expressions}}).
+#' Within a [lint()] function call, the linters in use are initialized with the provided
+#' arguments and fed with the source file (provided by [get_source_expressions()]).
 #'
-#' A data frame of all available linters can be retrieved using \code{\link{available_linters}()}.
+#' A data frame of all available linters can be retrieved using [available_linters()].
 #' Documentation for linters is structured into tags to allow for easier discovery.
 #'
 #' @evalRd rd_taglist()

--- a/R/assignment_linter.R
+++ b/R/assignment_linter.R
@@ -1,8 +1,9 @@
 #' Assignment linter
 #'
-#' Check that \code{<-} is always used for assignment.
+#' Check that `<-` is always used for assignment.
 #'
 #' @evalRd rd_tags("assignment_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 assignment_linter <- function() {
   Linter(function(source_file) {

--- a/R/assignment_spaces_linter.R
+++ b/R/assignment_spaces_linter.R
@@ -3,6 +3,7 @@
 #' Check that assignments only have one space before and after.
 #'
 #' @evalRd rd_tags("assignment_spaces_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 assignment_spaces_linter <- function() {
   Linter(function(source_file) {

--- a/R/backport_linter.R
+++ b/R/backport_linter.R
@@ -4,6 +4,7 @@
 #'
 #' @param r_version Minimum R version to test for compatibility
 #' @evalRd rd_tags("backport_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 backport_linter <- function(r_version = getRversion()) {
   Linter(function(source_file) {

--- a/R/cache.R
+++ b/R/cache.R
@@ -1,9 +1,7 @@
 #' Clear the lintr cache
 #'
-#' @param file filename whose cache to clear.  If you pass \code{NULL}, it will
-#' delete all of the caches.
-#' @param path directory to store caches.  Reads option 'lintr.cache_directory'
-#' as the default.
+#' @param file filename whose cache to clear. If you pass `NULL`, it will delete all of the caches.
+#' @param path directory to store caches. Reads option 'lintr.cache_directory' as the default.
 #' @return 0 for success, 1 for failure, invisibly.
 #' @export
 clear_cache <- function(file = NULL, path = NULL) {

--- a/R/closed_curly_linter.R
+++ b/R/closed_curly_linter.R
@@ -2,8 +2,9 @@
 #'
 #' Check that closed curly braces are on their own line unless they follow an else.
 #'
-#' @param allow_single_line if \code{TRUE}, allow an open and closed curly pair on the same line.
+#' @param allow_single_line if `TRUE`, allow an open and closed curly pair on the same line.
 #' @evalRd rd_tags("closed_curly_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 closed_curly_linter <- function(allow_single_line = FALSE) {
   Linter(function(source_file) {

--- a/R/commas_linter.R
+++ b/R/commas_linter.R
@@ -3,6 +3,7 @@
 #' Check that all commas are followed by spaces, but do not have spaces before them.
 #'
 #' @evalRd rd_tags("commas_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @importFrom utils head
 #' @export
 commas_linter <- function() {

--- a/R/comment_linters.R
+++ b/R/comment_linters.R
@@ -28,6 +28,7 @@ ops <- list(
 #' Check that there is no commented code outside roxygen blocks.
 #'
 #' @evalRd rd_tags("commented_code_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 commented_code_linter <- function() {
   Linter(function(source_file) {
@@ -86,6 +87,7 @@ parsable <- function(x) {
 #' @param todo Vector of strings that identify TODO comments.
 #'
 #' @evalRd rd_tags("todo_comment_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 todo_comment_linter <- function(todo = c("todo", "fixme")) {
   Linter(function(source_file) {

--- a/R/cyclocomp_linter.R
+++ b/R/cyclocomp_linter.R
@@ -1,10 +1,11 @@
 #' Cyclomatic complexity linter
 #'
-#' Check for overly complicated expressions. See \code{\link[cyclocomp]{cyclocomp}}.
+#' Check for overly complicated expressions. See [cyclocomp::cyclocomp()].
 #'
-#' @param complexity_limit expressions with a cyclomatic complexity higher than
-#'   this are linted, defaults to 15. See \code{\link[cyclocomp]{cyclocomp}}.
+#' @param complexity_limit expressions with a cyclomatic complexity higher than this are linted, defaults to 15.
+#' See [cyclocomp::cyclocomp()].
 #' @evalRd rd_tags("cyclocomp_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @importFrom cyclocomp cyclocomp
 #' @export
 cyclocomp_linter <- function(complexity_limit = 15L) {

--- a/R/duplicate_argument_linter.R
+++ b/R/duplicate_argument_linter.R
@@ -4,6 +4,7 @@
 #'
 #' @param except a character vector of function names as exceptions.
 #' @evalRd rd_tags("duplicate_argument_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 duplicate_argument_linter <- function(except = character()) {
   Linter(function(source_file) {

--- a/R/equals_na_linter.R
+++ b/R/equals_na_linter.R
@@ -1,8 +1,9 @@
 #' Equality check with NA linter
 #'
-#' Check for \code{x == NA} and \code{x != NA}
+#' Check for `x == NA` and `x != NA`
 #'
 #' @evalRd rd_tags("equals_na_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 equals_na_linter <- function() {
   Linter(function(source_file) {

--- a/R/exclude.R
+++ b/R/exclude.R
@@ -2,20 +2,19 @@
 #'
 #' @param lints that need to be filtered.
 #' @param exclusions manually specified exclusions
-#' @param ... additional arguments passed to \code{\link{parse_exclusions}}
+#' @param ... additional arguments passed to [parse_exclusions()]
 #' @details
 #' Exclusions can be specified in three different ways.
-#' \enumerate{
-#' \item{single line in the source file. default: \code{# nolint}, possibly followed by a listing of linters to exclude.
-#' If the listing is missing, all linters are excluded on that line. The default listing format is
-#' \code{# nolint: linter_name, linter2_name.}. There may not be anything between the colon and the line exclusion tag
-#' and the listing must be terminated with a full stop (\code{.}) for the linter list to be respected.}
-#' \item{line range in the source file. default: \code{# nolint start}, \code{# nolint end}.
-#' \code{#}\code{ nolint start} accepts linter lists in the same form as code{# nolint}.}
-#' \item{exclusions parameter, a named list of files with named lists of linters and lines to exclude them on,
-#' a named list of the files and lines to exclude, or just the filenames if you want to exclude the entire file,
-#' or the directory names if you want to exclude all files in a directory.}
-#' }
+#'
+#'  1. single line in the source file. default: `# nolint`, possibly followed by a listing of linters to exclude.
+#'     If the listing is missing, all linters are excluded on that line. The default listing format is
+#'     `# nolint: linter_name, linter2_name.`. There may not be anything between the colon and the line exclusion tag
+#'     and the listing must be terminated with a full stop (`.`) for the linter list to be respected.
+#'  2. line range in the source file. default: `# nolint start`, `# nolint end`. `# nolint start` accepts linter
+#'     lists in the same form as `# nolint`.
+#'  3. exclusions parameter, a named list of files with named lists of linters and lines to exclude them on, a named
+#'     list of the files and lines to exclude, or just the filenames if you want to exclude the entire file, or the
+#'     directory names if you want to exclude all files in a directory.
 exclude <- function(lints, exclusions = settings$exclusions, ...) {
   if (length(lints) <= 0) {
     return(lints)
@@ -75,9 +74,9 @@ line_info <- function(line_numbers, type = c("start", "end")) {
 #' @param exclude_start regular expression used to mark the start of an excluded range
 #' @param exclude_end regular expression used to mark the end of an excluded range
 #' @param exclude_linter regular expression used to capture a list of to-be-excluded linters immediately following a
-#' \code{exclude} or \code{exclude_start} marker.
+#' `exclude` or `exclude_start` marker.
 #' @param exclude_linter_sep regular expression used to split a linter list into indivdual linter names for exclusion.
-#' @param lines a character vector of the content lines of \code{file}
+#' @param lines a character vector of the content lines of `file`
 #'
 #' @return A possibly named list of excluded lines, possibly for specific linters.
 parse_exclusions <- function(file, exclude = settings$exclude,
@@ -170,24 +169,24 @@ add_exclusions <- function(exclusions, lines, linters_string, exclude_linter_sep
 #' Normalize lint exclusions
 #'
 #' @param x Exclusion specification
-#'  - A character vector of filenames or directories relative to \code{root}
+#'  - A character vector of filenames or directories relative to `root`
 #'  - A named list of integers specifying lines to be excluded per file
 #'  - A named list of named lists specifying linters and lines to be excluded for the linters per file.
 #' @param normalize_path Should the names of the returned exclusion list be normalized paths?
-#' If no, they will be relative to \code{root}.
+#' If no, they will be relative to `root`.
 #' @param root Base directory for relative filename resolution.
 #' @param pattern If non-NULL, only exclude files in excluded directories if they match
-#' \code{pattern}. Passed to \link[base]{list.files} if a directory is excluded.
+#' `pattern`. Passed to [list.files][base::list.files] if a directory is excluded.
 #'
 #' @return A named list of file exclusions.
 #' The names of the list specify the filenames to be excluded.
 #'
-#' Each file exclusion is a possibly named list containing line numbers to exclude, or the sentinel \code{Inf} for
+#' Each file exclusion is a possibly named list containing line numbers to exclude, or the sentinel `Inf` for
 #' completely excluded files. If the an entry is named, the exclusions only take effect for the linter with the same
 #' name.
 #'
-#' If \code{normalize_path} is \code{TRUE}, file names will be normalized relative to \code{root}.
-#' Otherwise the paths are left as provided (relative to \code{root} or absolute).
+#' If `normalize_path` is `TRUE`, file names will be normalized relative to `root`.
+#' Otherwise the paths are left as provided (relative to `root` or absolute).
 #'
 #' @keywords internal
 normalize_exclusions <- function(x, normalize_path = TRUE,

--- a/R/expect_lint.R
+++ b/R/expect_lint.R
@@ -1,28 +1,25 @@
 #' Lint expectation
 #'
-#' This is an expectation function to test that the lints produced by \code{lint} satisfy a number
-#' of checks.
+#' This is an expectation function to test that the lints produced by `lint` satisfy a number of checks.
 #'
-#' @param content a character vector for the file content to be linted, each vector element
-#' representing a line of text.
+#' @param content a character vector for the file content to be linted, each vector element representing a line of
+#' text.
 #' @param checks checks to be performed:
 #' \describe{
 #'   \item{NULL}{check that no lints are returned.}
-#'   \item{single string or regex object}{check that the single lint returned has a matching
-#'   message.}
-#'   \item{named list}{check that the single lint returned has fields that match. Accepted fields
-#'   are the same as those taken by \code{\link{Lint}}.}
-#'   \item{list of named lists}{for each of the multiple lints returned, check that it matches
-#'   the checks in the corresponding named list (as described in the point above).}
+#'   \item{single string or regex object}{check that the single lint returned has a matching message.}
+#'   \item{named list}{check that the single lint returned has fields that match. Accepted fields are the same as those
+#'     taken by [Lint()].}
+#'   \item{list of named lists}{for each of the multiple lints returned, check that it matches the checks in the
+#'     corresponding named list (as described in the point above).}
 #' }
 #' Named vectors are also accepted instead of named lists, but this is a compatibility feature that
 #' is not recommended for new code.
-#' @param ... arguments passed to \code{\link{lint}}, e.g. the linters or cache to use.
-#' @param file if not \code{NULL}, read content from the specified file rather than from \code{content}.
-#' @param language temporarily override Rs \code{LANGUAGE} envvar, controlling localisation of base
-#' R error messages. This makes testing them reproducible on all systems irrespective of their
-#' native R language setting.
-#' @return \code{NULL}, invisibly.
+#' @param ... arguments passed to [lint()], e.g. the linters or cache to use.
+#' @param file if not `NULL`, read content from the specified file rather than from `content`.
+#' @param language temporarily override Rs `LANGUAGE` envvar, controlling localisation of base R error messages.
+#' This makes testing them reproducible on all systems irrespective of their native R language setting.
+#' @return `NULL`, invisibly.
 #' @examples
 #' # no expected lint
 #' expect_lint("a", NULL, trailing_blank_lines_linter)
@@ -122,7 +119,7 @@ expect_lint <- function(content, checks, ..., file = NULL, language = "en") {
 #' lints in the package.  It can be used to ensure that your tests fail if the package
 #' contains lints.
 #'
-#' @param ... arguments passed to \code{\link{lint_package}}
+#' @param ... arguments passed to [lint_package()]
 #' @export
 expect_lint_free <- function(...) {
   testthat::skip_on_cran()

--- a/R/extraction_operator_linter.R
+++ b/R/extraction_operator_linter.R
@@ -4,6 +4,7 @@
 #' (interactive use).
 #'
 #' @evalRd rd_tags("extraction_operator_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 extraction_operator_linter <- function() {
   Linter(function(source_file) {

--- a/R/function_left_parentheses.R
+++ b/R/function_left_parentheses.R
@@ -3,6 +3,7 @@
 #' Check that all left parentheses in a function call do not have spaces before them.
 #'
 #' @evalRd rd_tags("function_left_parentheses_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 function_left_parentheses_linter <- function() { # nolint: object_length_linter.
   Linter(function(source_file) {

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -13,8 +13,9 @@
 #'
 #' @param filename the file to be parsed.
 #' @param lines a character vector of lines.
-#'   If \code{NULL}, then \code{filename} will be read.
+#'   If `NULL`, then `filename` will be read.
 #' @return A `list` with three components:
+#' \describe{
 #'   \item{expressions}{a `list` of
 #'   `n+1` objects. The first `n` elements correspond to each expression in
 #'   `filename`, and consist of a list of 9 elements:
@@ -49,6 +50,7 @@
 #'   }
 #'   \item{error}{A `Lint` object describing any parsing error.}
 #'   \item{lines}{The [readLines()] output for this file.}
+#' }
 #' @export
 #' @md
 get_source_expressions <- function(filename, lines = NULL) {

--- a/R/ids_with_token.R
+++ b/R/ids_with_token.R
@@ -2,17 +2,17 @@
 #'
 #' Gets the source IDs (row indices) corresponding to given token.
 #'
-#' @param source_file A list of source expressions, the result of a call to
-#' `\link{get_source_expressions}()`, for the desired filename.
+#' @param source_file A list of source expressions, the result of a call to [get_source_expressions()], for the desired
+#' filename.
 #' @param value Character. String corresponding to the token to search for.
 #' For example:
-#' \itemize{
-#'   \item "SYMBOL"
-#'   \item "FUNCTION"
-#'   \item "EQ_FORMALS"
-#'   \item "$"
-#'   \item "("
-#' }
+#'
+#'  * "SYMBOL"
+#'  * "FUNCTION"
+#'  * "EQ_FORMALS"
+#'  * "$"
+#'  * "("
+#'
 #' @param fun For additional flexibility, a function to search for in
 #' the `token` column of `parsed_content`. Typically `==` or `\%in\%`.
 #' @return `ids_with_token`: The indices of the `parsed_content` data frame

--- a/R/ids_with_token.R
+++ b/R/ids_with_token.R
@@ -14,7 +14,7 @@
 #'  * "("
 #'
 #' @param fun For additional flexibility, a function to search for in
-#' the `token` column of `parsed_content`. Typically `==` or `\%in\%`.
+#' the `token` column of `parsed_content`. Typically `==` or `%in%`.
 #' @return `ids_with_token`: The indices of the `parsed_content` data frame
 #' entry of the list of source expressions. Indices correspond to the
 #' *rows* where `fun` evaluates to `TRUE` for the `value` in the *token* column.

--- a/R/implicit_integer_linter.R
+++ b/R/implicit_integer_linter.R
@@ -1,8 +1,9 @@
 #' Implicit integer linter
 #'
-#' Check that integers are explicitly typed using the form \code{1L} instead of \code{1}.
+#' Check that integers are explicitly typed using the form `1L` instead of `1`.
 #'
 #' @evalRd rd_tags("implicit_integer_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 implicit_integer_linter <- function() {
   Linter(function(source_file) {

--- a/R/infix_spaces_linter.R
+++ b/R/infix_spaces_linter.R
@@ -34,6 +34,7 @@ infix_tokens <- c(unary_infix_tokens, binary_infix_tokens)
 #' Check that infix operators are surrounded by spaces.
 #'
 #' @evalRd rd_tags("infix_spaces_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 infix_spaces_linter <- function() {
   Linter(function(source_file) {

--- a/R/line_length_linter.R
+++ b/R/line_length_linter.R
@@ -1,9 +1,10 @@
 #' Line length linter
 #'
-#' Check that the line length of both comments and code is less than \code{length}.
+#' Check that the line length of both comments and code is less than `length`.
 #'
 #' @param length maximum line length allowed.
 #' @evalRd rd_tags("line_length_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 line_length_linter <- function(length = 80L) {
   Linter(function(source_file) {

--- a/R/lint.R
+++ b/R/lint.R
@@ -1,10 +1,9 @@
 #' Lintr
 #'
-#' Checks adherence to a given style, syntax errors and possible semantic
-#' issues.  Supports on the fly checking of R code edited with Emacs, Vim and
-#' Sublime Text.
+#' Checks adherence to a given style, syntax errors and possible semantic issues.
+#' Supports on the fly checking of R code edited with Emacs, Vim and Sublime Text.
 #' @name lintr
-#' @seealso \code{\link{lint}}, \code{\link{lint_package}}, \code{\link{lint_dir}}, \code{\link{linters}}
+#' @seealso [lint()], [lint_package()], [lint_dir()], [linters]
 #' @importFrom stats na.omit
 #' @importFrom utils capture.output getParseData relist
 NULL
@@ -15,17 +14,16 @@ NULL
 #'
 #' @name lint_file
 #'
-#' @param filename either the filename for a file to lint, or a character
-#' string of inline R code for linting. The latter [inline data] applies
-#' whenever \code{filename} has a newline character (\\n).
-#' @param linters a named list of linter functions to apply see
-#' \code{\link{linters}} for a full list of default and available linters.
-#' @param cache given a logical, toggle caching of lint results. If passed a
-#' character string, store the cache in this directory.
-#' @param ... additional arguments passed to \code{\link{exclude}}.
+#' @param filename either the filename for a file to lint, or a character string of inline R code for linting.
+#' The latter (inline data) applies whenever `filename` has a newline character (\\n).
+#' @param linters a named list of linter functions to apply see [linters] for a full list of default and available
+#' linters.
+#' @param cache given a logical, toggle caching of lint results. If passed a character string, store the cache in this
+#' directory.
+#' @param ... additional arguments passed to [exclude()].
 #' @param parse_settings whether to try and parse the settings.
-#' @param text Optional argument for supplying a string or lines directly,
-#'   e.g. if the file is already in memory or linting is being done ad hoc.
+#' @param text Optional argument for supplying a string or lines directly, e.g. if the file is already in memory or
+#' linting is being done ad hoc.
 #'
 #' @return A list of lint objects.
 #'
@@ -155,18 +153,15 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
 #' Lint a directory
 #'
 #' Apply one or more linters to all of the R files in a directory
-#' @param path the path to the base directory, by default,
-#' it will be searched in the parent directories of the current directory.
-#' @param relative_path if \code{TRUE}, file paths are printed using their path
-#' relative to the base directory.  If \code{FALSE}, use the full
-#' absolute path.
-#' @param ... additional arguments passed to \code{\link{lint}}, e.g.
-#' \code{cache} or \code{linters}.
-#' @param exclusions exclusions for \code{\link{exclude}}, relative to the
-#' package path.
-#' @param pattern pattern for files, by default it will take files with any of
-#' the extensions .R, .Rmd, .Rnw, .Rhtml, .Rrst, .Rtex, .Rtxt allowing for
-#' lowercase r (.r, ...)
+#'
+#' @param path the path to the base directory, by default, it will be searched in the parent directories of the current
+#' directory.
+#' @param relative_path if `TRUE`, file paths are printed using their path relative to the base directory.
+#'   If `FALSE`, use the full absolute path.
+#' @param ... additional arguments passed to [lint()], e.g. `cache` or `linters`.
+#' @param exclusions exclusions for [exclude()], relative to the package path.
+#' @param pattern pattern for files, by default it will take files with any of the extensions .R, .Rmd, .Rnw, .Rhtml,
+#' .Rrst, .Rtex, .Rtxt allowing for lowercase r (.r, ...)
 #' @inherit lint_file return
 #' @inheritParams lint_file
 #' @examples
@@ -257,8 +252,9 @@ lint_dir <- function(path = ".", relative_path = TRUE, ..., exclusions = list("r
 #' Lint a package
 #'
 #' Apply one or more linters to all of the R files in a package.
-#' @param path the path to the base directory of the package, if \code{NULL},
-#' it will be searched in the parent directories of the current directory.
+#'
+#' @param path the path to the base directory of the package, if `NULL`, it will be searched in the parent directories
+#' of the current directory.
 #' @inherit lint_file return
 #' @inheritParams lint_dir
 #' @examples
@@ -424,7 +420,7 @@ pkg_name <- function(path = find_package()) {
   }
 }
 
-#' Create a \code{lint} object
+#' Create a `lint` object
 #' @param filename path to the source file that was linted.
 #' @param line_number line number where the lint occurred.
 #' @param column_number column number where the lint occurred.
@@ -509,8 +505,8 @@ rstudio_source_markers <- function(lints) {
 
 #' Checkstyle Report for lint results
 #'
-#' Generate a report of the linting results using the
-#' \href{http://checkstyle.sourceforge.net/}{Checkstyle} XML format.
+#' Generate a report of the linting results using the [Checkstyle](http://checkstyle.sourceforge.net/) XML format.
+#'
 #' @param lints the linting results.
 #' @param filename the name of the output report
 #' @export

--- a/R/linter_tag_docs.R
+++ b/R/linter_tag_docs.R
@@ -5,6 +5,7 @@
 #' @description
 #' Linters highlighting code style issues.
 #' @evalRd rd_linters("style")
+#' @seealso [linters] for a complete list of linters available in lintr.
 NULL
 
 #' Robustness linters
@@ -12,6 +13,7 @@ NULL
 #' @description
 #' Linters highlighting code robustness issues, such as possibly wrong edge case behaviour.
 #' @evalRd rd_linters("robustness")
+#' @seealso [linters] for a complete list of linters available in lintr.
 NULL
 
 #' Best practices linters
@@ -19,6 +21,7 @@ NULL
 #' @description
 #' Linters checking the use of coding best practices, such as explicit typing of numeric constants.
 #' @evalRd rd_linters("best_practices")
+#' @seealso [linters] for a complete list of linters available in lintr.
 NULL
 
 #' Consistency linters
@@ -27,6 +30,7 @@ NULL
 #' Linters checking enforcing a consistent alternative if there are multiple syntactically valid ways to write
 #' something.
 #' @evalRd rd_linters("consistency")
+#' @seealso [linters] for a complete list of linters available in lintr.
 NULL
 
 #' Readability linters
@@ -34,6 +38,7 @@ NULL
 #' @description
 #' Linters highlighting readability issues, such as missing whitespace.
 #' @evalRd rd_linters("readability")
+#' @seealso [linters] for a complete list of linters available in lintr.
 NULL
 
 #' Correctness linters
@@ -41,6 +46,7 @@ NULL
 #' @description
 #' Linters highlighting possible programming mistakes, such as unused variables.
 #' @evalRd rd_linters("correctness")
+#' @seealso [linters] for a complete list of linters available in lintr.
 NULL
 
 #' Common mistake linters
@@ -48,6 +54,7 @@ NULL
 #' @description
 #' Linters highlighting common mistakes, such as duplicate arguments.
 #' @evalRd rd_linters("common_mistakes")
+#' @seealso [linters] for a complete list of linters available in lintr.
 NULL
 
 #' Efficiency linters
@@ -55,6 +62,7 @@ NULL
 #' @description
 #' Linters highlighting code efficiency problems, such as unneccessary function calls.
 #' @evalRd rd_linters("efficiency")
+#' @seealso [linters] for a complete list of linters available in lintr.
 NULL
 
 #' Configurable linters
@@ -62,4 +70,5 @@ NULL
 #' @description
 #' Generic linters which support custom configuration to your needs.
 #' @evalRd rd_linters("configurable")
+#' @seealso [linters] for a complete list of linters available in lintr.
 NULL

--- a/R/linter_tags.R
+++ b/R/linter_tags.R
@@ -6,17 +6,14 @@
 #'
 #' @section Package Authors:
 #'
-#' To implement \code{available_linters()} for your package, include a file \code{inst/lintr/linters.csv} in your
+#' To implement `available_linters()` for your package, include a file `inst/lintr/linters.csv` in your
 #' package.
 #' The CSV file must contain the columns 'linter' and 'tags', and be UTF-8 encoded.
 #' Additional columns will be silently ignored if present and the columns are identified by name.
 #' Each row describes a linter by
 #'
-#' \enumerate{
-#' \item{its function name (e.g. \code{"assignment_linter"}) in the column 'linter'.}
-#' \item{space-separated tags associated with the linter (e.g. \code{"style consistency default"}) in the column
-#'   'tags'.}
-#' }
+#'  1. its function name (e.g. `"assignment_linter"`) in the column 'linter'.
+#'  2. space-separated tags associated with the linter (e.g. `"style consistency default"`) in the column 'tags'.
 #'
 #' Tags should be snake_case.
 #'
@@ -37,6 +34,7 @@
 #'
 #' lintr_linters2 <- available_linters(c("lintr", "does-not-exist"))
 #' identical(lintr_linters, lintr_linters2)
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 available_linters <- function(packages = "lintr") {
   if (!is.character(packages)) {

--- a/R/missing_argument_linter.R
+++ b/R/missing_argument_linter.R
@@ -3,6 +3,7 @@
 #' Check for missing arguments in function calls.
 #' @param except a character vector of function names as exceptions.
 #' @evalRd rd_tags("missing_argument_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 missing_argument_linter <- function(except = c("switch", "alist")) {
   Linter(function(source_file) {

--- a/R/missing_package_linter.R
+++ b/R/missing_package_linter.R
@@ -1,9 +1,9 @@
 #' Missing package linter
 #'
-#' Check for missing packages in \code{library()}, \code{require()},
-#'   \code{loadNamespace()} and \code{requireNamespace()} calls.
+#' Check for missing packages in `library()`, `require()`, `loadNamespace()` and `requireNamespace()` calls.
 #'
 #' @evalRd rd_tags("missing_package_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 missing_package_linter <- function() {
   Linter(function(source_file) {

--- a/R/namespace_linter.R
+++ b/R/namespace_linter.R
@@ -1,13 +1,13 @@
 #' Namespace linter
 #'
 #' Check for missing packages and symbols in namespace calls.
-#' Note that using \code{check_exports=TRUE} or \code{check_nonexports=TRUE} will
-#'   load packages used in user code so it could potentially change the global state.
-#' @param check_exports Check if \code{symbol} is exported from \code{namespace} in
-#'   \code{namespace::symbol} calls.
-#' @param check_nonexports Check if \code{symbol} exists in \code{namespace} in
-#'   \code{namespace:::symbol} calls.
+#' Note that using `check_exports=TRUE` or `check_nonexports=TRUE` will load packages used in user code so it could
+#' potentially change the global state.
+#'
+#' @param check_exports Check if `symbol` is exported from `namespace` in `namespace::symbol` calls.
+#' @param check_nonexports Check if `symbol` exists in `namespace` in `namespace:::symbol` calls.
 #' @evalRd rd_tags("namespace_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
   Linter(function(source_file) {

--- a/R/no_tab_linter.R
+++ b/R/no_tab_linter.R
@@ -3,6 +3,7 @@
 #' Check that only spaces are used for indentation, not tabs.
 #' @include make_linter_from_regex.R
 #' @evalRd rd_tags("no_tab_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 no_tab_linter <- make_linter_from_regex(
   regex = rex(start, zero_or_more(regex("\\s")), one_or_more("\t")),

--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -7,6 +7,7 @@
 #'   \Sexpr[stage=render, results=rd]{lintr:::regexes_rd}. A name should
 #'   match at least one of these styles.
 #' @evalRd rd_tags("object_name_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 object_name_linter <- function(styles = c("snake_case", "symbols")) {
 
@@ -326,6 +327,7 @@ regexes_rd <- toString(paste0("\\sQuote{", names(style_regexes), "}"))
 #'
 #' @param length maximum variable name length allowed.
 #' @evalRd rd_tags("object_length_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 object_length_linter <- function(length = 30L) {
   make_object_linter(function(source_file, token) {

--- a/R/object_usage_linter.R
+++ b/R/object_usage_linter.R
@@ -1,10 +1,10 @@
 #' Object usage linter
 #'
-#' Check that closures have the proper usage using
-#' \code{\link[codetools]{checkUsage}}. Note that this runs
-#' \code{\link[base]{eval}} on the code, so do not use with untrusted code.
+#' Check that closures have the proper usage using [codetools::checkUsage()].
+#' Note that this runs [base::eval()] on the code, so do not use with untrusted code.
 #'
 #' @evalRd rd_tags("object_usage_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 object_usage_linter <- function() {
   Linter(function(source_file) {

--- a/R/open_curly_linter.R
+++ b/R/open_curly_linter.R
@@ -2,8 +2,9 @@
 #'
 #' Check that opening curly braces are never on their own line and are always followed by a newline.
 #'
-#' @param allow_single_line if \code{TRUE}, allow an open and closed curly pair on the same line.
+#' @param allow_single_line if `TRUE`, allow an open and closed curly pair on the same line.
 #' @evalRd rd_tags("open_curly_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 open_curly_linter <- function(allow_single_line = FALSE) {
   Linter(function(source_file) {

--- a/R/package_hooks_linter.R
+++ b/R/package_hooks_linter.R
@@ -4,6 +4,7 @@
 #'   namespace hooks that will cause `R CMD check` issues.
 #'
 #' @evalRd rd_tags("package_hooks_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 package_hooks_linter <- function() {
   Linter(function(source_file) {

--- a/R/paren_body_linter.R
+++ b/R/paren_body_linter.R
@@ -3,6 +3,7 @@
 #' Check that there is a space between right parenthesis and a body expression.
 #'
 #' @evalRd rd_tags("paren_body_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 paren_body_linter <- function() {
   Linter(function(source_file) {

--- a/R/paren_brace_linter.R
+++ b/R/paren_brace_linter.R
@@ -3,6 +3,7 @@
 #' Check that there is a space between right parentheses and an opening curly brace.
 #'
 #' @evalRd rd_tags("paren_brace_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 paren_brace_linter <- function() {
   Linter(function(source_file) {

--- a/R/path_linters.R
+++ b/R/path_linters.R
@@ -195,7 +195,7 @@ absolute_path_linter <- function(lax = TRUE) {
 
 #' Non-portable path linter
 #'
-#' Check that \code{\link{file.path}()} is used to construct safe and portable paths.
+#' Check that [file.path()] is used to construct safe and portable paths.
 #'
 #' @inheritParams absolute_path_linter
 #' @evalRd rd_tags("nonportable_path_linter")

--- a/R/path_linters.R
+++ b/R/path_linters.R
@@ -175,14 +175,13 @@ make_path_linter <- function(path_function, message, linter, name = linter_auto_
 #' Check that no absolute paths are used (e.g. "/var", "C:\\System", "~/docs").
 #'
 #' @param lax Less stringent linting, leading to fewer false positives.
-#' If \code{TRUE}, only lint path strings, which
+#' If `TRUE`, only lint path strings, which
 #'
-#' \itemize{
-#' \item contain at least two path elements, with one having at least two characters and
-#' \item contain only alphanumeric chars (including UTF-8), spaces, and win32-allowed punctuation
-#' }
+#' * contain at least two path elements, with one having at least two characters and
+#' * contain only alphanumeric chars (including UTF-8), spaces, and win32-allowed punctuation
 #'
 #' @evalRd rd_tags("absolute_path_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 absolute_path_linter <- function(lax = TRUE) {
   make_path_linter(
@@ -199,6 +198,7 @@ absolute_path_linter <- function(lax = TRUE) {
 #'
 #' @inheritParams absolute_path_linter
 #' @evalRd rd_tags("nonportable_path_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 nonportable_path_linter <- function(lax = TRUE) {
   make_path_linter(

--- a/R/pipe_call_linter.R
+++ b/R/pipe_call_linter.R
@@ -1,9 +1,10 @@
 #' Pipe call linter
 #'
 #' Force explicit calls in magrittr pipes, e.g.,
-#' \code{1:3 \%>\% sum()} instead of \code{1:3 \%>\% sum}.
+#' `1:3 %>% sum()` instead of `1:3 %>% sum`.
 #'
 #' @evalRd rd_tags("pipe_call_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 pipe_call_linter <- function() {
   Linter(function(source_file) {

--- a/R/pipe_continuation_linter.R
+++ b/R/pipe_continuation_linter.R
@@ -3,6 +3,7 @@
 #' Check that each step in a pipeline is on a new line, or the entire pipe fits on one line.
 #'
 #' @evalRd rd_tags("pipe_continuation_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @importFrom xml2 xml_find_all as_list
 #' @export
 pipe_continuation_linter <- function() {

--- a/R/semicolon_terminator_linter.R
+++ b/R/semicolon_terminator_linter.R
@@ -2,11 +2,13 @@
 #'
 #' Check that no semicolons terminate expressions.
 #'
-#' @param semicolon A character vector defining which semicolons to report:\describe{
+#' @param semicolon A character vector defining which semicolons to report:
+#' \describe{
 #'   \item{compound}{Semicolons that separate two statements on the same line.}
 #'   \item{trailing}{Semicolons following the last statement on the line.}
 #' }
 #' @evalRd rd_tags("semicolon_terminator_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 semicolon_terminator_linter <- function(semicolon = c("compound", "trailing")) {
   Linter(function(source_file) {

--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -1,12 +1,11 @@
 #' Sequence linter
 #'
-#' Check for \code{1:length(...)}, \code{1:nrow(...)},
-#' \code{1:ncol(...)}, \code{1:NROW(...)} and \code{1:NCOL(...)}
-#' expressions. These often cause bugs when the right-hand side is zero.
-#' It is safer to use \code{\link[base]{seq_len}} or
-#' \code{\link[base]{seq_along}} instead.
+#' Check for `1:length(...)`, `1:nrow(...)`, `1:ncol(...)`, `1:NROW(...)` and `1:NCOL(...)` expressions.
+#' These often cause bugs when the right-hand side is zero.
+#' It is safer to use [base::seq_len()] or [base::seq_along()] instead.
 #'
 #' @evalRd rd_tags("seq_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 seq_linter <- function() {
   Linter(function(source_file) {

--- a/R/settings.R
+++ b/R/settings.R
@@ -2,16 +2,14 @@
 #' Read lintr settings
 #'
 #' Lintr searches for settings for a given source file in the following order.
-#' \enumerate{
-#'   \item options defined as \code{linter.setting}.
-#'   \item \code{linter_file} in the same directory
-#'   \item \code{linter_file} in the project directory
-#'   \item \code{linter_file} in the user home directory
-#'   \item \code{\link{default_settings}}
-#' }
+#'  1. options defined as `linter.setting`.
+#'  2. `linter_file` in the same directory
+#'  3. `linter_file` in the project directory
+#'  4. `linter_file` in the user home directory
+#'  5. [default_settings()]
 #'
-#' The default linter_file name is \code{.lintr} but it can be changed with option
-#' \code{lintr.linter_file}.  This file is a dcf file, see \code{\link[base]{read.dcf}} for details.
+#' The default linter_file name is `.lintr` but it can be changed with option `lintr.linter_file`.
+#' This file is a dcf file, see [base::read.dcf()] for details.
 #' @param filename source file to be linted
 read_settings <- function(filename) {
   clear_settings()

--- a/R/single_quotes_linter.R
+++ b/R/single_quotes_linter.R
@@ -3,6 +3,7 @@
 #' Check that only double quotes are used to delimit string constants.
 #'
 #' @evalRd rd_tags("single_quotes_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 single_quotes_linter <- function() {
   Linter(function(source_file) {

--- a/R/spaces_inside_linter.R
+++ b/R/spaces_inside_linter.R
@@ -4,6 +4,7 @@
 #' opening delimiter or directly preceding a closing delimiter.
 #'
 #' @evalRd rd_tags("spaces_inside_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 spaces_inside_linter <- function() {
   Linter(function(source_file) {

--- a/R/spaces_left_parentheses_linter.R
+++ b/R/spaces_left_parentheses_linter.R
@@ -3,6 +3,7 @@
 #' Check that all left parentheses have a space before them unless they are in a function call.
 #'
 #' @evalRd rd_tags("spaces_left_parentheses_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 spaces_left_parentheses_linter <- function() {
   Linter(function(source_file) {

--- a/R/sprintf_linter.R
+++ b/R/sprintf_linter.R
@@ -1,9 +1,10 @@
-#' \code{sprintf} linter
+#' `sprintf` linter
 #'
 #' Check for an inconsistent number of arguments or arguments with incompatible types (for literal arguments) in
-#' \code{sprintf} calls.
+#' `sprintf` calls.
 #'
 #' @evalRd rd_tags("sprintf_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 sprintf_linter <- function() {
   Linter(function(source_file) {

--- a/R/trailing_blank_lines_linter.R
+++ b/R/trailing_blank_lines_linter.R
@@ -3,6 +3,7 @@
 #' Check that there are no trailing blank lines in source code.
 #'
 #' @evalRd rd_tags("trailing_blank_lines_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 trailing_blank_lines_linter <- function() {
   Linter(function(source_file) {

--- a/R/trailing_whitespace_linter.R
+++ b/R/trailing_whitespace_linter.R
@@ -3,6 +3,7 @@
 #' Check that there are no space characters at the end of source lines.
 #'
 #' @evalRd rd_tags("trailing_whitespace_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 trailing_whitespace_linter <- function() {
   Linter(function(source_file) {

--- a/R/undesirable_function_linter.R
+++ b/R/undesirable_function_linter.R
@@ -1,14 +1,14 @@
 #' Undesirable function linter
 #'
-#' Report the use of undesirable functions, e.g. \code{\link[base]{return}}, \code{\link[base]{options}}, or
-#' \code{\link[base]{sapply}} and suggest an alternative.
+#' Report the use of undesirable functions, e.g. [base::return()], [base::options()], or
+#' [base::sapply()] and suggest an alternative.
 #'
-#' @param fun Named character vector, where the names are the names of the
-#'   undesirable functions, and the values are the text for the alternative
-#'   function to use (or \code{NA}).
-#' @param symbol_is_undesirable Whether to consider the use of an undesirable
-#'   function name as a symbol undesirable or not.
+#' @param fun Named character vector, where the names are the names of the undesirable functions, and the values are
+#'   the text for the alternative function to use (or `NA`).
+#' @param symbol_is_undesirable Whether to consider the use of an undesirable function name as a symbol undesirable
+#'   or not.
 #' @evalRd rd_tags("undesirable_function_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 undesirable_function_linter <- function(fun = default_undesirable_functions,
                                         symbol_is_undesirable = TRUE) {

--- a/R/undesirable_operator_linter.R
+++ b/R/undesirable_operator_linter.R
@@ -10,12 +10,13 @@ op_types <- c(
 
 #' Undesirable operator linter
 #'
-#' Report the use of undesirable operators, e.g. \code{\link[base:ns-dblcolon]{`:::`}} or
-#' \code{\link[base:assignOps]{`<<-`}} and suggest an alternative.
+#' Report the use of undesirable operators, e.g. [`:::`][base::ns-dblcolon] or
+#' [`<<-`][base::assignOps] and suggest an alternative.
 #'
-#' @param op Named character vector, where the names are the names of the undesirable operators,
-#'           and the values are the text for the alternative operator to use (or \code{NA}).
+#' @param op Named character vector, where the names are the names of the undesirable operators, and the values are
+#'   the text for the alternative operator to use (or `NA`).
 #' @evalRd rd_tags("undesirable_operator_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 undesirable_operator_linter <- function(op = default_undesirable_operators) {
   Linter(function(source_file) {

--- a/R/unneeded_concatenation_linter.R
+++ b/R/unneeded_concatenation_linter.R
@@ -1,8 +1,9 @@
 #' Unneeded concatenation linter
 #'
-#' Check that the \code{c} function is not used without arguments nor with a single constant.
+#' Check that the `c` function is not used without arguments nor with a single constant.
 #'
 #' @evalRd rd_tags("unneeded_concatenation_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 unneeded_concatenation_linter <- function() {
   Linter(function(source_file) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -239,10 +239,11 @@ reset_lang <- function(old_lang) {
   if (is.na(old_lang)) Sys.unsetenv("LANGUAGE") else Sys.setenv(LANGUAGE = old_lang)
 }
 
-#' Create a \code{linter} closure
-#' @param fun A function that takes a source file and returns \code{lint} objects.
+#' Create a `linter` closure
+#'
+#' @param fun A function that takes a source file and returns `lint` objects.
 #' @param name Default name of the Linter.
-#' Lints produced by the linter will be labelled with \code{name} by default.
+#' Lints produced by the linter will be labelled with `name` by default.
 #' @return The same function with its class set to 'linter'.
 #' @export
 Linter <- function(fun, name = linter_auto_name()) { # nolint: object_name_linter.

--- a/R/with_id.R
+++ b/R/with_id.R
@@ -2,9 +2,8 @@
 #' Extract row by ID
 #'
 #' @describeIn ids_with_token
-#' Return the row of the `parsed_content` entry of the
-#' `\link{get_source_expressions}()` object. Typically used in conjunction with
-#' `ids_with_token` to iterate over rows containing desired tokens.
+#' Return the row of the `parsed_content` entry of the `[get_source_expressions]()` object. Typically used in
+#' conjunction with `ids_with_token` to iterate over rows containing desired tokens.
 #'
 #' @param id Integer. The index corresponding to the desired row
 #' of `parsed_content`.

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,12 +1,12 @@
 #' Modify lintr defaults
 #'
-#' Make a new list based on \pkg{lintr}'s default linters, undesirable
-#' operators or functions. The result of this function is meant to be passed to
-#' the `linters` argument of `lint()`, or put in your configuration file.
+#' Make a new list based on \pkg{lintr}'s default linters, undesirable operators or functions.
+#' The result of this function is meant to be passed to the `linters` argument of `lint()`, or put in your
+#' configuration file.
 #'
-#' @param ... arguments of elements to change. If unnamed, the argument is named. If the named
-#' argument already exists in "default", it is replaced by the new element. If it does not exist,
-#' it is added. If the value is \code{NULL}, the element is removed.
+#' @param ... arguments of elements to change. If unnamed, the argument is named. If the named argument already exists
+#' in "default", it is replaced by the new element. If it does not exist, it is added. If the value is `NULL`, the
+#' element is removed.
 #' @param default list of elements to modify.
 #' @return A modified list of elements.
 #' @examples
@@ -71,14 +71,14 @@ with_defaults <- function(..., default = default_linters) {
 
 #' Default linters
 #'
-#' @description List of default linters for \code{\link{lint}}. Use
-#' \code{\link{with_defaults}} to customize it.
+#' @description List of default linters for [lint()]. Use
+#' [with_defaults()] to customize it.
 #'
-#' The set of default linters is as follows (any parameterised linters, eg,
-#' \code{line_length_linter} use their default argument(s), see \code{?
-#' <linter_name>} for details):
+#' The set of default linters is as follows (any parameterised linters, eg, `line_length_linter` use their default
+#' argument(s), see `?<linter_name>` for details):
 #'
 #' @evalRd rd_linters("default")
+#' @seealso [linters] for a complete list of linters available in lintr.
 #'
 #' @export
 default_linters <- with_defaults(
@@ -112,9 +112,10 @@ default_linters <- with_defaults(
 
 #' Default undesirable functions and operators
 #'
-#' Lists of function names and operators for \code{\link{undesirable_function_linter}} and
-#' \code{\link{undesirable_operator_linter}}. There is a list for the default elements and another
-#' that contains all available elements. Use \code{\link{with_defaults}} to produce a custom list.
+#' Lists of function names and operators for [undesirable_function_linter()] and [undesirable_operator_linter()].
+#' There is a list for the default elements and another that contains all available elements.
+#' Use [with_defaults()] to produce a custom list.
+#'
 #' @format A named list of character strings.
 #' @rdname default_undesirable_functions
 #' @export
@@ -198,7 +199,7 @@ default_undesirable_operators <- do.call(with_defaults, c(
 
 
 #' Default lintr settings
-#' @seealso \code{\link{read_settings}}, \code{\link{default_linters}}
+#' @seealso [read_settings()], [default_linters()]
 #' @export
 default_settings <- NULL
 

--- a/man/T_and_F_symbol_linter.Rd
+++ b/man/T_and_F_symbol_linter.Rd
@@ -9,6 +9,9 @@ T_and_F_symbol_linter()
 \description{
 Avoid the symbols \code{T} and \code{F} (for \code{TRUE} and \code{FALSE}).
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=best_practices_linters]{best_practices}, \link[=consistency_linters]{consistency}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=robustness_linters]{robustness}, \link[=style_linters]{style}
 }

--- a/man/absolute_path_linter.Rd
+++ b/man/absolute_path_linter.Rd
@@ -9,7 +9,6 @@ absolute_path_linter(lax = TRUE)
 \arguments{
 \item{lax}{Less stringent linting, leading to fewer false positives.
 If \code{TRUE}, only lint path strings, which
-
 \itemize{
 \item contain at least two path elements, with one having at least two characters and
 \item contain only alphanumeric chars (including UTF-8), spaces, and win32-allowed punctuation
@@ -17,6 +16,9 @@ If \code{TRUE}, only lint path strings, which
 }
 \description{
 Check that no absolute paths are used (e.g. "/var", "C:\\System", "~/docs").
+}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=best_practices_linters]{best_practices}, \link[=configurable_linters]{configurable}, \link[=robustness_linters]{robustness}

--- a/man/assignment_linter.Rd
+++ b/man/assignment_linter.Rd
@@ -7,7 +7,10 @@
 assignment_linter()
 }
 \description{
-Check that \code{<-} is always used for assignment.
+Check that \verb{<-} is always used for assignment.
+}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=consistency_linters]{consistency}, \link[=default_linters]{default}, \link[=style_linters]{style}

--- a/man/assignment_spaces_linter.Rd
+++ b/man/assignment_spaces_linter.Rd
@@ -9,6 +9,9 @@ assignment_spaces_linter()
 \description{
 Check that assignments only have one space before and after.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }

--- a/man/available_linters.Rd
+++ b/man/available_linters.Rd
@@ -29,11 +29,9 @@ package.
 The CSV file must contain the columns 'linter' and 'tags', and be UTF-8 encoded.
 Additional columns will be silently ignored if present and the columns are identified by name.
 Each row describes a linter by
-
 \enumerate{
-\item{its function name (e.g. \code{"assignment_linter"}) in the column 'linter'.}
-\item{space-separated tags associated with the linter (e.g. \code{"style consistency default"}) in the column
-  'tags'.}
+\item its function name (e.g. \code{"assignment_linter"}) in the column 'linter'.
+\item space-separated tags associated with the linter (e.g. \code{"style consistency default"}) in the column 'tags'.
 }
 
 Tags should be snake_case.
@@ -47,4 +45,7 @@ available_linters("does-not-exist")
 
 lintr_linters2 <- available_linters(c("lintr", "does-not-exist"))
 identical(lintr_linters, lintr_linters2)
+}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }

--- a/man/backport_linter.Rd
+++ b/man/backport_linter.Rd
@@ -12,6 +12,9 @@ backport_linter(r_version = getRversion())
 \description{
 Check for usage of unavailable functions. Not reliable for testing r-devel dependencies.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=configurable_linters]{configurable}, \link[=robustness_linters]{robustness}
 }

--- a/man/best_practices_linters.Rd
+++ b/man/best_practices_linters.Rd
@@ -6,6 +6,9 @@
 \description{
 Linters checking the use of coding best practices, such as explicit typing of numeric constants.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Linters}{
 The following linters are tagged with 'best_practices':
 \itemize{

--- a/man/checkstyle_output.Rd
+++ b/man/checkstyle_output.Rd
@@ -12,6 +12,5 @@ checkstyle_output(lints, filename = "lintr_results.xml")
 \item{filename}{the name of the output report}
 }
 \description{
-Generate a report of the linting results using the
-\href{http://checkstyle.sourceforge.net/}{Checkstyle} XML format.
+Generate a report of the linting results using the \href{http://checkstyle.sourceforge.net/}{Checkstyle} XML format.
 }

--- a/man/clear_cache.Rd
+++ b/man/clear_cache.Rd
@@ -7,11 +7,9 @@
 clear_cache(file = NULL, path = NULL)
 }
 \arguments{
-\item{file}{filename whose cache to clear.  If you pass \code{NULL}, it will
-delete all of the caches.}
+\item{file}{filename whose cache to clear. If you pass \code{NULL}, it will delete all of the caches.}
 
-\item{path}{directory to store caches.  Reads option 'lintr.cache_directory'
-as the default.}
+\item{path}{directory to store caches. Reads option 'lintr.cache_directory' as the default.}
 }
 \value{
 0 for success, 1 for failure, invisibly.

--- a/man/closed_curly_linter.Rd
+++ b/man/closed_curly_linter.Rd
@@ -12,6 +12,9 @@ closed_curly_linter(allow_single_line = FALSE)
 \description{
 Check that closed curly braces are on their own line unless they follow an else.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=configurable_linters]{configurable}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }

--- a/man/commas_linter.Rd
+++ b/man/commas_linter.Rd
@@ -9,6 +9,9 @@ commas_linter()
 \description{
 Check that all commas are followed by spaces, but do not have spaces before them.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }

--- a/man/commented_code_linter.Rd
+++ b/man/commented_code_linter.Rd
@@ -9,6 +9,9 @@ commented_code_linter()
 \description{
 Check that there is no commented code outside roxygen blocks.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=best_practices_linters]{best_practices}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }

--- a/man/common_mistakes_linters.Rd
+++ b/man/common_mistakes_linters.Rd
@@ -6,6 +6,9 @@
 \description{
 Linters highlighting common mistakes, such as duplicate arguments.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Linters}{
 The following linters are tagged with 'common_mistakes':
 \itemize{

--- a/man/configurable_linters.Rd
+++ b/man/configurable_linters.Rd
@@ -6,6 +6,9 @@
 \description{
 Generic linters which support custom configuration to your needs.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Linters}{
 The following linters are tagged with 'configurable':
 \itemize{

--- a/man/consistency_linters.Rd
+++ b/man/consistency_linters.Rd
@@ -7,6 +7,9 @@
 Linters checking enforcing a consistent alternative if there are multiple syntactically valid ways to write
 something.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Linters}{
 The following linters are tagged with 'consistency':
 \itemize{

--- a/man/correctness_linters.Rd
+++ b/man/correctness_linters.Rd
@@ -6,6 +6,9 @@
 \description{
 Linters highlighting possible programming mistakes, such as unused variables.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Linters}{
 The following linters are tagged with 'correctness':
 \itemize{

--- a/man/cyclocomp_linter.Rd
+++ b/man/cyclocomp_linter.Rd
@@ -7,11 +7,14 @@
 cyclocomp_linter(complexity_limit = 15L)
 }
 \arguments{
-\item{complexity_limit}{expressions with a cyclomatic complexity higher than
-this are linted, defaults to 15. See \code{\link[cyclocomp]{cyclocomp}}.}
+\item{complexity_limit}{expressions with a cyclomatic complexity higher than this are linted, defaults to 15.
+See \code{\link[cyclocomp:cyclocomp]{cyclocomp::cyclocomp()}}.}
 }
 \description{
-Check for overly complicated expressions. See \code{\link[cyclocomp]{cyclocomp}}.
+Check for overly complicated expressions. See \code{\link[cyclocomp:cyclocomp]{cyclocomp::cyclocomp()}}.
+}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=best_practices_linters]{best_practices}, \link[=configurable_linters]{configurable}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/default_linters.Rd
+++ b/man/default_linters.Rd
@@ -11,12 +11,14 @@ An object of class \code{list} of length 25.
 default_linters
 }
 \description{
-List of default linters for \code{\link{lint}}. Use
-\code{\link{with_defaults}} to customize it.
+List of default linters for \code{\link[=lint]{lint()}}. Use
+\code{\link[=with_defaults]{with_defaults()}} to customize it.
 
-The set of default linters is as follows (any parameterised linters, eg,
-\code{line_length_linter} use their default argument(s), see \code{?
-<linter_name>} for details):
+The set of default linters is as follows (any parameterised linters, eg, \code{line_length_linter} use their default
+argument(s), see \verb{?<linter_name>} for details):
+}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \keyword{datasets}
 \section{Linters}{

--- a/man/default_settings.Rd
+++ b/man/default_settings.Rd
@@ -14,6 +14,6 @@ default_settings
 Default lintr settings
 }
 \seealso{
-\code{\link{read_settings}}, \code{\link{default_linters}}
+\code{\link[=read_settings]{read_settings()}}, \code{\link[=default_linters]{default_linters()}}
 }
 \keyword{datasets}

--- a/man/default_undesirable_functions.Rd
+++ b/man/default_undesirable_functions.Rd
@@ -26,8 +26,8 @@ all_undesirable_operators
 default_undesirable_operators
 }
 \description{
-Lists of function names and operators for \code{\link{undesirable_function_linter}} and
-\code{\link{undesirable_operator_linter}}. There is a list for the default elements and another
-that contains all available elements. Use \code{\link{with_defaults}} to produce a custom list.
+Lists of function names and operators for \code{\link[=undesirable_function_linter]{undesirable_function_linter()}} and \code{\link[=undesirable_operator_linter]{undesirable_operator_linter()}}.
+There is a list for the default elements and another that contains all available elements.
+Use \code{\link[=with_defaults]{with_defaults()}} to produce a custom list.
 }
 \keyword{datasets}

--- a/man/duplicate_argument_linter.Rd
+++ b/man/duplicate_argument_linter.Rd
@@ -12,6 +12,9 @@ duplicate_argument_linter(except = character())
 \description{
 Check for duplicate arguments in function calls.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=common_mistakes_linters]{common_mistakes}, \link[=configurable_linters]{configurable}, \link[=correctness_linters]{correctness}
 }

--- a/man/efficiency_linters.Rd
+++ b/man/efficiency_linters.Rd
@@ -6,6 +6,9 @@
 \description{
 Linters highlighting code efficiency problems, such as unneccessary function calls.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Linters}{
 The following linters are tagged with 'efficiency':
 \itemize{

--- a/man/equals_na_linter.Rd
+++ b/man/equals_na_linter.Rd
@@ -9,6 +9,9 @@ equals_na_linter()
 \description{
 Check for \code{x == NA} and \code{x != NA}
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=common_mistakes_linters]{common_mistakes}, \link[=correctness_linters]{correctness}, \link[=default_linters]{default}, \link[=robustness_linters]{robustness}
 }

--- a/man/exclude.Rd
+++ b/man/exclude.Rd
@@ -11,7 +11,7 @@ exclude(lints, exclusions = settings$exclusions, ...)
 
 \item{exclusions}{manually specified exclusions}
 
-\item{...}{additional arguments passed to \code{\link{parse_exclusions}}}
+\item{...}{additional arguments passed to \code{\link[=parse_exclusions]{parse_exclusions()}}}
 }
 \description{
 Exclude lines or files from linting
@@ -19,14 +19,14 @@ Exclude lines or files from linting
 \details{
 Exclusions can be specified in three different ways.
 \enumerate{
-\item{single line in the source file. default: \code{# nolint}, possibly followed by a listing of linters to exclude.
+\item single line in the source file. default: \verb{# nolint}, possibly followed by a listing of linters to exclude.
 If the listing is missing, all linters are excluded on that line. The default listing format is
-\code{# nolint: linter_name, linter2_name.}. There may not be anything between the colon and the line exclusion tag
-and the listing must be terminated with a full stop (\code{.}) for the linter list to be respected.}
-\item{line range in the source file. default: \code{# nolint start}, \code{# nolint end}.
-\code{#}\code{ nolint start} accepts linter lists in the same form as code{# nolint}.}
-\item{exclusions parameter, a named list of files with named lists of linters and lines to exclude them on,
-a named list of the files and lines to exclude, or just the filenames if you want to exclude the entire file,
-or the directory names if you want to exclude all files in a directory.}
+\verb{# nolint: linter_name, linter2_name.}. There may not be anything between the colon and the line exclusion tag
+and the listing must be terminated with a full stop (\code{.}) for the linter list to be respected.
+\item line range in the source file. default: \verb{# nolint start}, \verb{# nolint end}. \verb{# nolint start} accepts linter
+lists in the same form as \verb{# nolint}.
+\item exclusions parameter, a named list of files with named lists of linters and lines to exclude them on, a named
+list of the files and lines to exclude, or just the filenames if you want to exclude the entire file, or the
+directory names if you want to exclude all files in a directory.
 }
 }

--- a/man/expect_lint.Rd
+++ b/man/expect_lint.Rd
@@ -7,36 +7,33 @@
 expect_lint(content, checks, ..., file = NULL, language = "en")
 }
 \arguments{
-\item{content}{a character vector for the file content to be linted, each vector element
-representing a line of text.}
+\item{content}{a character vector for the file content to be linted, each vector element representing a line of
+text.}
 
 \item{checks}{checks to be performed:
 \describe{
-  \item{NULL}{check that no lints are returned.}
-  \item{single string or regex object}{check that the single lint returned has a matching
-  message.}
-  \item{named list}{check that the single lint returned has fields that match. Accepted fields
-  are the same as those taken by \code{\link{Lint}}.}
-  \item{list of named lists}{for each of the multiple lints returned, check that it matches
-  the checks in the corresponding named list (as described in the point above).}
+\item{NULL}{check that no lints are returned.}
+\item{single string or regex object}{check that the single lint returned has a matching message.}
+\item{named list}{check that the single lint returned has fields that match. Accepted fields are the same as those
+taken by \code{\link[=Lint]{Lint()}}.}
+\item{list of named lists}{for each of the multiple lints returned, check that it matches the checks in the
+corresponding named list (as described in the point above).}
 }
 Named vectors are also accepted instead of named lists, but this is a compatibility feature that
 is not recommended for new code.}
 
-\item{...}{arguments passed to \code{\link{lint}}, e.g. the linters or cache to use.}
+\item{...}{arguments passed to \code{\link[=lint]{lint()}}, e.g. the linters or cache to use.}
 
 \item{file}{if not \code{NULL}, read content from the specified file rather than from \code{content}.}
 
-\item{language}{temporarily override Rs \code{LANGUAGE} envvar, controlling localisation of base
-R error messages. This makes testing them reproducible on all systems irrespective of their
-native R language setting.}
+\item{language}{temporarily override Rs \code{LANGUAGE} envvar, controlling localisation of base R error messages.
+This makes testing them reproducible on all systems irrespective of their native R language setting.}
 }
 \value{
 \code{NULL}, invisibly.
 }
 \description{
-This is an expectation function to test that the lints produced by \code{lint} satisfy a number
-of checks.
+This is an expectation function to test that the lints produced by \code{lint} satisfy a number of checks.
 }
 \examples{
 # no expected lint

--- a/man/expect_lint_free.Rd
+++ b/man/expect_lint_free.Rd
@@ -7,7 +7,7 @@
 expect_lint_free(...)
 }
 \arguments{
-\item{...}{arguments passed to \code{\link{lint_package}}}
+\item{...}{arguments passed to \code{\link[=lint_package]{lint_package()}}}
 }
 \description{
 This function is a thin wrapper around lint_package that simply tests there are no

--- a/man/extraction_operator_linter.Rd
+++ b/man/extraction_operator_linter.Rd
@@ -7,8 +7,11 @@
 extraction_operator_linter()
 }
 \description{
-Check that the `[[` operator is used when extracting a single element from an object, not `[` (subsetting) nor `$`
+Check that the \code{[[} operator is used when extracting a single element from an object, not \code{[} (subsetting) nor \code{$}
 (interactive use).
+}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=best_practices_linters]{best_practices}, \link[=style_linters]{style}

--- a/man/function_left_parentheses_linter.Rd
+++ b/man/function_left_parentheses_linter.Rd
@@ -9,6 +9,9 @@ function_left_parentheses_linter()
 \description{
 Check that all left parentheses in a function call do not have spaces before them.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }

--- a/man/get_source_expressions.Rd
+++ b/man/get_source_expressions.Rd
@@ -14,6 +14,7 @@ If \code{NULL}, then \code{filename} will be read.}
 }
 \value{
 A \code{list} with three components:
+\describe{
 \item{expressions}{a \code{list} of
 \code{n+1} objects. The first \code{n} elements correspond to each expression in
 \code{filename}, and consist of a list of 9 elements:
@@ -48,6 +49,7 @@ newline (as determined by \code{\link[=readLines]{readLines()}} producing a corr
 }
 \item{error}{A \code{Lint} object describing any parsing error.}
 \item{lines}{The \code{\link[=readLines]{readLines()}} output for this file.}
+}
 }
 \description{
 This object is given as input to each linter

--- a/man/ids_with_token.Rd
+++ b/man/ids_with_token.Rd
@@ -24,7 +24,7 @@ For example:
 }}
 
 \item{fun}{For additional flexibility, a function to search for in
-the \code{token} column of \code{parsed_content}. Typically \code{==} or \verb{\\\%in\\\%}.}
+the \code{token} column of \code{parsed_content}. Typically \code{==} or \code{\%in\%}.}
 
 \item{id}{Integer. The index corresponding to the desired row
 of \code{parsed_content}.}

--- a/man/ids_with_token.Rd
+++ b/man/ids_with_token.Rd
@@ -10,39 +10,38 @@ ids_with_token(source_file, value, fun = `==`)
 with_id(source_file, id)
 }
 \arguments{
-\item{source_file}{A list of source expressions, the result of a call to
-`\link{get_source_expressions}()`, for the desired filename.}
+\item{source_file}{A list of source expressions, the result of a call to \code{\link[=get_source_expressions]{get_source_expressions()}}, for the desired
+filename.}
 
 \item{value}{Character. String corresponding to the token to search for.
 For example:
 \itemize{
-  \item "SYMBOL"
-  \item "FUNCTION"
-  \item "EQ_FORMALS"
-  \item "$"
-  \item "("
+\item "SYMBOL"
+\item "FUNCTION"
+\item "EQ_FORMALS"
+\item "$"
+\item "("
 }}
 
 \item{fun}{For additional flexibility, a function to search for in
-the `token` column of `parsed_content`. Typically `==` or `\%in\%`.}
+the \code{token} column of \code{parsed_content}. Typically \code{==} or \verb{\\\%in\\\%}.}
 
 \item{id}{Integer. The index corresponding to the desired row
-of `parsed_content`.}
+of \code{parsed_content}.}
 }
 \value{
-`ids_with_token`: The indices of the `parsed_content` data frame
+\code{ids_with_token}: The indices of the \code{parsed_content} data frame
 entry of the list of source expressions. Indices correspond to the
-*rows* where `fun` evaluates to `TRUE` for the `value` in the *token* column.
+\emph{rows} where \code{fun} evaluates to \code{TRUE} for the \code{value} in the \emph{token} column.
 
-`with_id`: A data frame corresponding to the row(s) specified in `id`.
+\code{with_id}: A data frame corresponding to the row(s) specified in \code{id}.
 }
 \description{
 Gets the source IDs (row indices) corresponding to given token.
 }
 \section{Functions}{
 \itemize{
-\item \code{with_id}: Return the row of the `parsed_content` entry of the
-`\link{get_source_expressions}()` object. Typically used in conjunction with
-`ids_with_token` to iterate over rows containing desired tokens.
+\item \code{with_id}: Return the row of the \code{parsed_content} entry of the \verb{[get_source_expressions]()} object. Typically used in
+conjunction with \code{ids_with_token} to iterate over rows containing desired tokens.
 }}
 

--- a/man/implicit_integer_linter.Rd
+++ b/man/implicit_integer_linter.Rd
@@ -9,6 +9,9 @@ implicit_integer_linter()
 \description{
 Check that integers are explicitly typed using the form \code{1L} instead of \code{1}.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=best_practices_linters]{best_practices}, \link[=consistency_linters]{consistency}, \link[=style_linters]{style}
 }

--- a/man/infix_spaces_linter.Rd
+++ b/man/infix_spaces_linter.Rd
@@ -9,6 +9,9 @@ infix_spaces_linter()
 \description{
 Check that infix operators are surrounded by spaces.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }

--- a/man/line_length_linter.Rd
+++ b/man/line_length_linter.Rd
@@ -15,3 +15,6 @@ Check that the line length of both comments and code is less than \code{length}.
 \section{Tags}{
 \link[=configurable_linters]{configurable}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }
+\section{Tags}{
+\link[=configurable_linters]{configurable}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
+}

--- a/man/line_length_linter.Rd
+++ b/man/line_length_linter.Rd
@@ -12,8 +12,8 @@ line_length_linter(length = 80L)
 \description{
 Check that the line length of both comments and code is less than \code{length}.
 }
-\section{Tags}{
-\link[=configurable_linters]{configurable}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=configurable_linters]{configurable}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/lint_dir.Rd
+++ b/man/lint_dir.Rd
@@ -15,22 +15,18 @@ lint_dir(
 )
 }
 \arguments{
-\item{path}{the path to the base directory, by default,
-it will be searched in the parent directories of the current directory.}
+\item{path}{the path to the base directory, by default, it will be searched in the parent directories of the current
+directory.}
 
-\item{relative_path}{if \code{TRUE}, file paths are printed using their path
-relative to the base directory.  If \code{FALSE}, use the full
-absolute path.}
+\item{relative_path}{if \code{TRUE}, file paths are printed using their path relative to the base directory.
+If \code{FALSE}, use the full absolute path.}
 
-\item{...}{additional arguments passed to \code{\link{lint}}, e.g.
-\code{cache} or \code{linters}.}
+\item{...}{additional arguments passed to \code{\link[=lint]{lint()}}, e.g. \code{cache} or \code{linters}.}
 
-\item{exclusions}{exclusions for \code{\link{exclude}}, relative to the
-package path.}
+\item{exclusions}{exclusions for \code{\link[=exclude]{exclude()}}, relative to the package path.}
 
-\item{pattern}{pattern for files, by default it will take files with any of
-the extensions .R, .Rmd, .Rnw, .Rhtml, .Rrst, .Rtex, .Rtxt allowing for
-lowercase r (.r, ...)}
+\item{pattern}{pattern for files, by default it will take files with any of the extensions .R, .Rmd, .Rnw, .Rhtml,
+.Rrst, .Rtex, .Rtxt allowing for lowercase r (.r, ...)}
 
 \item{parse_settings}{whether to try and parse the settings.}
 }

--- a/man/lint_file.Rd
+++ b/man/lint_file.Rd
@@ -15,22 +15,21 @@ lint(
 )
 }
 \arguments{
-\item{filename}{either the filename for a file to lint, or a character
-string of inline R code for linting. The latter [inline data] applies
-whenever \code{filename} has a newline character (\\n).}
+\item{filename}{either the filename for a file to lint, or a character string of inline R code for linting.
+The latter (inline data) applies whenever \code{filename} has a newline character (\\n).}
 
-\item{linters}{a named list of linter functions to apply see
-\code{\link{linters}} for a full list of default and available linters.}
+\item{linters}{a named list of linter functions to apply see \link{linters} for a full list of default and available
+linters.}
 
-\item{cache}{given a logical, toggle caching of lint results. If passed a
-character string, store the cache in this directory.}
+\item{cache}{given a logical, toggle caching of lint results. If passed a character string, store the cache in this
+directory.}
 
-\item{...}{additional arguments passed to \code{\link{exclude}}.}
+\item{...}{additional arguments passed to \code{\link[=exclude]{exclude()}}.}
 
 \item{parse_settings}{whether to try and parse the settings.}
 
-\item{text}{Optional argument for supplying a string or lines directly,
-e.g. if the file is already in memory or linting is being done ad hoc.}
+\item{text}{Optional argument for supplying a string or lines directly, e.g. if the file is already in memory or
+linting is being done ad hoc.}
 }
 \value{
 A list of lint objects.

--- a/man/lint_package.Rd
+++ b/man/lint_package.Rd
@@ -13,18 +13,15 @@ lint_package(
 )
 }
 \arguments{
-\item{path}{the path to the base directory of the package, if \code{NULL},
-it will be searched in the parent directories of the current directory.}
+\item{path}{the path to the base directory of the package, if \code{NULL}, it will be searched in the parent directories
+of the current directory.}
 
-\item{relative_path}{if \code{TRUE}, file paths are printed using their path
-relative to the base directory.  If \code{FALSE}, use the full
-absolute path.}
+\item{relative_path}{if \code{TRUE}, file paths are printed using their path relative to the base directory.
+If \code{FALSE}, use the full absolute path.}
 
-\item{...}{additional arguments passed to \code{\link{lint}}, e.g.
-\code{cache} or \code{linters}.}
+\item{...}{additional arguments passed to \code{\link[=lint]{lint()}}, e.g. \code{cache} or \code{linters}.}
 
-\item{exclusions}{exclusions for \code{\link{exclude}}, relative to the
-package path.}
+\item{exclusions}{exclusions for \code{\link[=exclude]{exclude()}}, relative to the package path.}
 
 \item{parse_settings}{whether to try and parse the settings.}
 }

--- a/man/linters.Rd
+++ b/man/linters.Rd
@@ -5,13 +5,13 @@
 \title{Available linters}
 \description{
 A variety of linters is available in \pkg{lintr}. The most popular ones are readily
-accessible through \code{\link{default_linters}}, though there are additional ones you may want
+accessible through \code{\link[=default_linters]{default_linters()}}, though there are additional ones you may want
 to use.
 
-Within a \code{\link{lint}} function call, the linters in use are initialized with the provided
-arguments and fed with the source file (provided by \code{\link{get_source_expressions}}).
+Within a \code{\link[=lint]{lint()}} function call, the linters in use are initialized with the provided
+arguments and fed with the source file (provided by \code{\link[=get_source_expressions]{get_source_expressions()}}).
 
-A data frame of all available linters can be retrieved using \code{\link{available_linters}()}.
+A data frame of all available linters can be retrieved using \code{\link[=available_linters]{available_linters()}}.
 Documentation for linters is structured into tags to allow for easier discovery.
 }
 \section{Tags}{

--- a/man/lintr.Rd
+++ b/man/lintr.Rd
@@ -4,10 +4,9 @@
 \alias{lintr}
 \title{Lintr}
 \description{
-Checks adherence to a given style, syntax errors and possible semantic
-issues.  Supports on the fly checking of R code edited with Emacs, Vim and
-Sublime Text.
+Checks adherence to a given style, syntax errors and possible semantic issues.
+Supports on the fly checking of R code edited with Emacs, Vim and Sublime Text.
 }
 \seealso{
-\code{\link{lint}}, \code{\link{lint_package}}, \code{\link{lint_dir}}, \code{\link{linters}}
+\code{\link[=lint]{lint()}}, \code{\link[=lint_package]{lint_package()}}, \code{\link[=lint_dir]{lint_dir()}}, \link{linters}
 }

--- a/man/missing_argument_linter.Rd
+++ b/man/missing_argument_linter.Rd
@@ -12,6 +12,9 @@ missing_argument_linter(except = c("switch", "alist"))
 \description{
 Check for missing arguments in function calls.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=common_mistakes_linters]{common_mistakes}, \link[=configurable_linters]{configurable}, \link[=correctness_linters]{correctness}
 }

--- a/man/missing_package_linter.Rd
+++ b/man/missing_package_linter.Rd
@@ -7,8 +7,10 @@
 missing_package_linter()
 }
 \description{
-Check for missing packages in \code{library()}, \code{require()},
-  \code{loadNamespace()} and \code{requireNamespace()} calls.
+Check for missing packages in \code{library()}, \code{require()}, \code{loadNamespace()} and \code{requireNamespace()} calls.
+}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=common_mistakes_linters]{common_mistakes}, \link[=robustness_linters]{robustness}

--- a/man/namespace_linter.Rd
+++ b/man/namespace_linter.Rd
@@ -7,16 +7,17 @@
 namespace_linter(check_exports = TRUE, check_nonexports = TRUE)
 }
 \arguments{
-\item{check_exports}{Check if \code{symbol} is exported from \code{namespace} in
-\code{namespace::symbol} calls.}
+\item{check_exports}{Check if \code{symbol} is exported from \code{namespace} in \code{namespace::symbol} calls.}
 
-\item{check_nonexports}{Check if \code{symbol} exists in \code{namespace} in
-\code{namespace:::symbol} calls.}
+\item{check_nonexports}{Check if \code{symbol} exists in \code{namespace} in \code{namespace:::symbol} calls.}
 }
 \description{
 Check for missing packages and symbols in namespace calls.
-Note that using \code{check_exports=TRUE} or \code{check_nonexports=TRUE} will
-  load packages used in user code so it could potentially change the global state.
+Note that using \code{check_exports=TRUE} or \code{check_nonexports=TRUE} will load packages used in user code so it could
+potentially change the global state.
+}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=configurable_linters]{configurable}, \link[=correctness_linters]{correctness}, \link[=robustness_linters]{robustness}

--- a/man/no_tab_linter.Rd
+++ b/man/no_tab_linter.Rd
@@ -9,6 +9,9 @@ no_tab_linter()
 \description{
 Check that only spaces are used for indentation, not tabs.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=consistency_linters]{consistency}, \link[=default_linters]{default}, \link[=style_linters]{style}
 }

--- a/man/nonportable_path_linter.Rd
+++ b/man/nonportable_path_linter.Rd
@@ -9,17 +9,16 @@ nonportable_path_linter(lax = TRUE)
 \arguments{
 \item{lax}{Less stringent linting, leading to fewer false positives.
 If \code{TRUE}, only lint path strings, which
-
 \itemize{
 \item contain at least two path elements, with one having at least two characters and
 \item contain only alphanumeric chars (including UTF-8), spaces, and win32-allowed punctuation
 }}
 }
 \description{
-Check that \code{\link{file.path}()} is used to construct safe and portable paths.
+Check that \code{\link[=file.path]{file.path()}} is used to construct safe and portable paths.
 }
-\section{Tags}{
-\link[=best_practices_linters]{best_practices}, \link[=configurable_linters]{configurable}, \link[=robustness_linters]{robustness}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=best_practices_linters]{best_practices}, \link[=configurable_linters]{configurable}, \link[=robustness_linters]{robustness}

--- a/man/nonportable_path_linter.Rd
+++ b/man/nonportable_path_linter.Rd
@@ -21,3 +21,6 @@ Check that \code{\link{file.path}()} is used to construct safe and portable path
 \section{Tags}{
 \link[=best_practices_linters]{best_practices}, \link[=configurable_linters]{configurable}, \link[=robustness_linters]{robustness}
 }
+\section{Tags}{
+\link[=best_practices_linters]{best_practices}, \link[=configurable_linters]{configurable}, \link[=robustness_linters]{robustness}
+}

--- a/man/normalize_exclusions.Rd
+++ b/man/normalize_exclusions.Rd
@@ -8,9 +8,11 @@ normalize_exclusions(x, normalize_path = TRUE, root = getwd(), pattern = NULL)
 }
 \arguments{
 \item{x}{Exclusion specification
-- A character vector of filenames or directories relative to \code{root}
-- A named list of integers specifying lines to be excluded per file
-- A named list of named lists specifying linters and lines to be excluded for the linters per file.}
+\itemize{
+\item A character vector of filenames or directories relative to \code{root}
+\item A named list of integers specifying lines to be excluded per file
+\item A named list of named lists specifying linters and lines to be excluded for the linters per file.
+}}
 
 \item{normalize_path}{Should the names of the returned exclusion list be normalized paths?
 If no, they will be relative to \code{root}.}
@@ -18,7 +20,7 @@ If no, they will be relative to \code{root}.}
 \item{root}{Base directory for relative filename resolution.}
 
 \item{pattern}{If non-NULL, only exclude files in excluded directories if they match
-\code{pattern}. Passed to \link[base]{list.files} if a directory is excluded.}
+\code{pattern}. Passed to \link[base:list.files]{list.files} if a directory is excluded.}
 }
 \value{
 A named list of file exclusions.

--- a/man/object_length_linter.Rd
+++ b/man/object_length_linter.Rd
@@ -12,6 +12,9 @@ object_length_linter(length = 30L)
 \description{
 Check that object names are not too long.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=configurable_linters]{configurable}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }

--- a/man/object_name_linter.Rd
+++ b/man/object_name_linter.Rd
@@ -18,3 +18,6 @@ The default naming styles are "snake_case" and "symbols".
 \section{Tags}{
 \link[=configurable_linters]{configurable}, \link[=consistency_linters]{consistency}, \link[=default_linters]{default}, \link[=style_linters]{style}
 }
+\section{Tags}{
+\link[=configurable_linters]{configurable}, \link[=consistency_linters]{consistency}, \link[=default_linters]{default}, \link[=style_linters]{style}
+}

--- a/man/object_name_linter.Rd
+++ b/man/object_name_linter.Rd
@@ -15,8 +15,8 @@ match at least one of these styles.}
 Check that object names conform to a naming style.
 The default naming styles are "snake_case" and "symbols".
 }
-\section{Tags}{
-\link[=configurable_linters]{configurable}, \link[=consistency_linters]{consistency}, \link[=default_linters]{default}, \link[=style_linters]{style}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=configurable_linters]{configurable}, \link[=consistency_linters]{consistency}, \link[=default_linters]{default}, \link[=style_linters]{style}

--- a/man/object_usage_linter.Rd
+++ b/man/object_usage_linter.Rd
@@ -7,9 +7,11 @@
 object_usage_linter()
 }
 \description{
-Check that closures have the proper usage using
-\code{\link[codetools]{checkUsage}}. Note that this runs
-\code{\link[base]{eval}} on the code, so do not use with untrusted code.
+Check that closures have the proper usage using \code{\link[codetools:checkUsage]{codetools::checkUsage()}}.
+Note that this runs \code{\link[base:eval]{base::eval()}} on the code, so do not use with untrusted code.
+}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=correctness_linters]{correctness}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/open_curly_linter.Rd
+++ b/man/open_curly_linter.Rd
@@ -12,6 +12,9 @@ open_curly_linter(allow_single_line = FALSE)
 \description{
 Check that opening curly braces are never on their own line and are always followed by a newline.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=configurable_linters]{configurable}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }

--- a/man/package_hooks_linter.Rd
+++ b/man/package_hooks_linter.Rd
@@ -7,8 +7,11 @@
 package_hooks_linter()
 }
 \description{
-Check various common "gotchas" in [.onLoad()], [.onAttach()], [.Last.lib()], and [.onDetach()]
-  namespace hooks that will cause `R CMD check` issues.
+Check various common "gotchas" in \code{\link[=.onLoad]{.onLoad()}}, \code{\link[=.onAttach]{.onAttach()}}, \code{\link[=.Last.lib]{.Last.lib()}}, and \code{\link[=.onDetach]{.onDetach()}}
+namespace hooks that will cause \verb{R CMD check} issues.
+}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=correctness_linters]{correctness}, \link[=style_linters]{style}

--- a/man/paren_body_linter.Rd
+++ b/man/paren_body_linter.Rd
@@ -9,6 +9,9 @@ paren_body_linter()
 \description{
 Check that there is a space between right parenthesis and a body expression.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }

--- a/man/paren_brace_linter.Rd
+++ b/man/paren_brace_linter.Rd
@@ -9,6 +9,9 @@ paren_brace_linter()
 \description{
 Check that there is a space between right parentheses and an opening curly brace.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }

--- a/man/pipe_call_linter.Rd
+++ b/man/pipe_call_linter.Rd
@@ -10,8 +10,8 @@ pipe_call_linter()
 Force explicit calls in magrittr pipes, e.g.,
 \code{1:3 \%>\% sum()} instead of \code{1:3 \%>\% sum}.
 }
-\section{Tags}{
-\link[=readability_linters]{readability}, \link[=style_linters]{style}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/pipe_call_linter.Rd
+++ b/man/pipe_call_linter.Rd
@@ -13,3 +13,6 @@ Force explicit calls in magrittr pipes, e.g.,
 \section{Tags}{
 \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }
+\section{Tags}{
+\link[=readability_linters]{readability}, \link[=style_linters]{style}
+}

--- a/man/pipe_continuation_linter.Rd
+++ b/man/pipe_continuation_linter.Rd
@@ -9,6 +9,9 @@ pipe_continuation_linter()
 \description{
 Check that each step in a pipeline is on a new line, or the entire pipe fits on one line.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }

--- a/man/read_settings.Rd
+++ b/man/read_settings.Rd
@@ -12,14 +12,14 @@ read_settings(filename)
 \description{
 Lintr searches for settings for a given source file in the following order.
 \enumerate{
-  \item options defined as \code{linter.setting}.
-  \item \code{linter_file} in the same directory
-  \item \code{linter_file} in the project directory
-  \item \code{linter_file} in the user home directory
-  \item \code{\link{default_settings}}
+\item options defined as \code{linter.setting}.
+\item \code{linter_file} in the same directory
+\item \code{linter_file} in the project directory
+\item \code{linter_file} in the user home directory
+\item \code{\link[=default_settings]{default_settings()}}
 }
 }
 \details{
-The default linter_file name is \code{.lintr} but it can be changed with option
-\code{lintr.linter_file}.  This file is a dcf file, see \code{\link[base]{read.dcf}} for details.
+The default linter_file name is \code{.lintr} but it can be changed with option \code{lintr.linter_file}.
+This file is a dcf file, see \code{\link[base:dcf]{base::read.dcf()}} for details.
 }

--- a/man/readability_linters.Rd
+++ b/man/readability_linters.Rd
@@ -6,6 +6,9 @@
 \description{
 Linters highlighting readability issues, such as missing whitespace.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Linters}{
 The following linters are tagged with 'readability':
 \itemize{

--- a/man/robustness_linters.Rd
+++ b/man/robustness_linters.Rd
@@ -6,6 +6,9 @@
 \description{
 Linters highlighting code robustness issues, such as possibly wrong edge case behaviour.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Linters}{
 The following linters are tagged with 'robustness':
 \itemize{

--- a/man/semicolon_terminator_linter.Rd
+++ b/man/semicolon_terminator_linter.Rd
@@ -7,16 +7,17 @@
 semicolon_terminator_linter(semicolon = c("compound", "trailing"))
 }
 \arguments{
-\item{semicolon}{A character vector defining which semicolons to report:\describe{
-  \item{compound}{Semicolons that separate two statements on the same line.}
-  \item{trailing}{Semicolons following the last statement on the line.}
+\item{semicolon}{A character vector defining which semicolons to report:
+\describe{
+\item{compound}{Semicolons that separate two statements on the same line.}
+\item{trailing}{Semicolons following the last statement on the line.}
 }}
 }
 \description{
 Check that no semicolons terminate expressions.
 }
-\section{Tags}{
-\link[=configurable_linters]{configurable}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=configurable_linters]{configurable}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/semicolon_terminator_linter.Rd
+++ b/man/semicolon_terminator_linter.Rd
@@ -18,3 +18,6 @@ Check that no semicolons terminate expressions.
 \section{Tags}{
 \link[=configurable_linters]{configurable}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }
+\section{Tags}{
+\link[=configurable_linters]{configurable}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
+}

--- a/man/seq_linter.Rd
+++ b/man/seq_linter.Rd
@@ -7,11 +7,12 @@
 seq_linter()
 }
 \description{
-Check for \code{1:length(...)}, \code{1:nrow(...)},
-\code{1:ncol(...)}, \code{1:NROW(...)} and \code{1:NCOL(...)}
-expressions. These often cause bugs when the right-hand side is zero.
-It is safer to use \code{\link[base]{seq_len}} or
-\code{\link[base]{seq_along}} instead.
+Check for \code{1:length(...)}, \code{1:nrow(...)}, \code{1:ncol(...)}, \code{1:NROW(...)} and \code{1:NCOL(...)} expressions.
+These often cause bugs when the right-hand side is zero.
+It is safer to use \code{\link[base:seq]{base::seq_len()}} or \code{\link[base:seq]{base::seq_along()}} instead.
+}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=best_practices_linters]{best_practices}, \link[=consistency_linters]{consistency}, \link[=default_linters]{default}, \link[=efficiency_linters]{efficiency}, \link[=robustness_linters]{robustness}

--- a/man/single_quotes_linter.Rd
+++ b/man/single_quotes_linter.Rd
@@ -12,3 +12,6 @@ Check that only double quotes are used to delimit string constants.
 \section{Tags}{
 \link[=consistency_linters]{consistency}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }
+\section{Tags}{
+\link[=consistency_linters]{consistency}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
+}

--- a/man/single_quotes_linter.Rd
+++ b/man/single_quotes_linter.Rd
@@ -9,8 +9,8 @@ single_quotes_linter()
 \description{
 Check that only double quotes are used to delimit string constants.
 }
-\section{Tags}{
-\link[=consistency_linters]{consistency}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=consistency_linters]{consistency}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/spaces_inside_linter.Rd
+++ b/man/spaces_inside_linter.Rd
@@ -13,3 +13,6 @@ opening delimiter or directly preceding a closing delimiter.
 \section{Tags}{
 \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }
+\section{Tags}{
+\link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
+}

--- a/man/spaces_inside_linter.Rd
+++ b/man/spaces_inside_linter.Rd
@@ -10,8 +10,8 @@ spaces_inside_linter()
 Check that parentheses and square brackets do not have spaces directly inside them, i.e., directly following an
 opening delimiter or directly preceding a closing delimiter.
 }
-\section{Tags}{
-\link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/spaces_left_parentheses_linter.Rd
+++ b/man/spaces_left_parentheses_linter.Rd
@@ -9,6 +9,9 @@ spaces_left_parentheses_linter()
 \description{
 Check that all left parentheses have a space before them unless they are in a function call.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }

--- a/man/sprintf_linter.Rd
+++ b/man/sprintf_linter.Rd
@@ -10,8 +10,8 @@ sprintf_linter()
 Check for an inconsistent number of arguments or arguments with incompatible types (for literal arguments) in
 \code{sprintf} calls.
 }
-\section{Tags}{
-\link[=common_mistakes_linters]{common_mistakes}, \link[=correctness_linters]{correctness}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=common_mistakes_linters]{common_mistakes}, \link[=correctness_linters]{correctness}

--- a/man/sprintf_linter.Rd
+++ b/man/sprintf_linter.Rd
@@ -13,3 +13,6 @@ Check for an inconsistent number of arguments or arguments with incompatible typ
 \section{Tags}{
 \link[=common_mistakes_linters]{common_mistakes}, \link[=correctness_linters]{correctness}
 }
+\section{Tags}{
+\link[=common_mistakes_linters]{common_mistakes}, \link[=correctness_linters]{correctness}
+}

--- a/man/style_linters.Rd
+++ b/man/style_linters.Rd
@@ -6,6 +6,9 @@
 \description{
 Linters highlighting code style issues.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Linters}{
 The following linters are tagged with 'style':
 \itemize{

--- a/man/todo_comment_linter.Rd
+++ b/man/todo_comment_linter.Rd
@@ -12,6 +12,9 @@ todo_comment_linter(todo = c("todo", "fixme"))
 \description{
 Check that the source contains no TODO comments (case-insensitive).
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=configurable_linters]{configurable}, \link[=style_linters]{style}
 }

--- a/man/trailing_blank_lines_linter.Rd
+++ b/man/trailing_blank_lines_linter.Rd
@@ -9,8 +9,8 @@ trailing_blank_lines_linter()
 \description{
 Check that there are no trailing blank lines in source code.
 }
-\section{Tags}{
-\link[=default_linters]{default}, \link[=style_linters]{style}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=default_linters]{default}, \link[=style_linters]{style}

--- a/man/trailing_blank_lines_linter.Rd
+++ b/man/trailing_blank_lines_linter.Rd
@@ -12,3 +12,6 @@ Check that there are no trailing blank lines in source code.
 \section{Tags}{
 \link[=default_linters]{default}, \link[=style_linters]{style}
 }
+\section{Tags}{
+\link[=default_linters]{default}, \link[=style_linters]{style}
+}

--- a/man/trailing_whitespace_linter.Rd
+++ b/man/trailing_whitespace_linter.Rd
@@ -9,6 +9,9 @@ trailing_whitespace_linter()
 \description{
 Check that there are no space characters at the end of source lines.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=default_linters]{default}, \link[=style_linters]{style}
 }

--- a/man/undesirable_function_linter.Rd
+++ b/man/undesirable_function_linter.Rd
@@ -24,3 +24,6 @@ Report the use of undesirable functions, e.g. \code{\link[base]{return}}, \code{
 \section{Tags}{
 \link[=best_practices_linters]{best_practices}, \link[=configurable_linters]{configurable}, \link[=efficiency_linters]{efficiency}, \link[=robustness_linters]{robustness}, \link[=style_linters]{style}
 }
+\section{Tags}{
+\link[=best_practices_linters]{best_practices}, \link[=configurable_linters]{configurable}, \link[=efficiency_linters]{efficiency}, \link[=robustness_linters]{robustness}, \link[=style_linters]{style}
+}

--- a/man/undesirable_function_linter.Rd
+++ b/man/undesirable_function_linter.Rd
@@ -10,19 +10,18 @@ undesirable_function_linter(
 )
 }
 \arguments{
-\item{fun}{Named character vector, where the names are the names of the
-undesirable functions, and the values are the text for the alternative
-function to use (or \code{NA}).}
+\item{fun}{Named character vector, where the names are the names of the undesirable functions, and the values are
+the text for the alternative function to use (or \code{NA}).}
 
-\item{symbol_is_undesirable}{Whether to consider the use of an undesirable
-function name as a symbol undesirable or not.}
+\item{symbol_is_undesirable}{Whether to consider the use of an undesirable function name as a symbol undesirable
+or not.}
 }
 \description{
-Report the use of undesirable functions, e.g. \code{\link[base]{return}}, \code{\link[base]{options}}, or
-\code{\link[base]{sapply}} and suggest an alternative.
+Report the use of undesirable functions, e.g. \code{\link[base:function]{base::return()}}, \code{\link[base:options]{base::options()}}, or
+\code{\link[base:lapply]{base::sapply()}} and suggest an alternative.
 }
-\section{Tags}{
-\link[=best_practices_linters]{best_practices}, \link[=configurable_linters]{configurable}, \link[=efficiency_linters]{efficiency}, \link[=robustness_linters]{robustness}, \link[=style_linters]{style}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=best_practices_linters]{best_practices}, \link[=configurable_linters]{configurable}, \link[=efficiency_linters]{efficiency}, \link[=robustness_linters]{robustness}, \link[=style_linters]{style}

--- a/man/undesirable_operator_linter.Rd
+++ b/man/undesirable_operator_linter.Rd
@@ -7,15 +7,15 @@
 undesirable_operator_linter(op = default_undesirable_operators)
 }
 \arguments{
-\item{op}{Named character vector, where the names are the names of the undesirable operators,
-and the values are the text for the alternative operator to use (or \code{NA}).}
+\item{op}{Named character vector, where the names are the names of the undesirable operators, and the values are
+the text for the alternative operator to use (or \code{NA}).}
 }
 \description{
-Report the use of undesirable operators, e.g. \code{\link[base:ns-dblcolon]{`:::`}} or
-\code{\link[base:assignOps]{`<<-`}} and suggest an alternative.
+Report the use of undesirable operators, e.g. \code{\link[base:ns-dblcolon]{:::}} or
+\code{\link[base:assignOps]{<<-}} and suggest an alternative.
 }
-\section{Tags}{
-\link[=best_practices_linters]{best_practices}, \link[=configurable_linters]{configurable}, \link[=efficiency_linters]{efficiency}, \link[=robustness_linters]{robustness}, \link[=style_linters]{style}
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
 \link[=best_practices_linters]{best_practices}, \link[=configurable_linters]{configurable}, \link[=efficiency_linters]{efficiency}, \link[=robustness_linters]{robustness}, \link[=style_linters]{style}

--- a/man/undesirable_operator_linter.Rd
+++ b/man/undesirable_operator_linter.Rd
@@ -17,3 +17,6 @@ Report the use of undesirable operators, e.g. \code{\link[base:ns-dblcolon]{`:::
 \section{Tags}{
 \link[=best_practices_linters]{best_practices}, \link[=configurable_linters]{configurable}, \link[=efficiency_linters]{efficiency}, \link[=robustness_linters]{robustness}, \link[=style_linters]{style}
 }
+\section{Tags}{
+\link[=best_practices_linters]{best_practices}, \link[=configurable_linters]{configurable}, \link[=efficiency_linters]{efficiency}, \link[=robustness_linters]{robustness}, \link[=style_linters]{style}
+}

--- a/man/unneeded_concatenation_linter.Rd
+++ b/man/unneeded_concatenation_linter.Rd
@@ -9,6 +9,9 @@ unneeded_concatenation_linter()
 \description{
 Check that the \code{c} function is not used without arguments nor with a single constant.
 }
+\seealso{
+\link{linters} for a complete list of linters available in lintr.
+}
 \section{Tags}{
 \link[=efficiency_linters]{efficiency}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }

--- a/man/with_defaults.Rd
+++ b/man/with_defaults.Rd
@@ -7,9 +7,9 @@
 with_defaults(..., default = default_linters)
 }
 \arguments{
-\item{...}{arguments of elements to change. If unnamed, the argument is named. If the named
-argument already exists in "default", it is replaced by the new element. If it does not exist,
-it is added. If the value is \code{NULL}, the element is removed.}
+\item{...}{arguments of elements to change. If unnamed, the argument is named. If the named argument already exists
+in "default", it is replaced by the new element. If it does not exist, it is added. If the value is \code{NULL}, the
+element is removed.}
 
 \item{default}{list of elements to modify.}
 }
@@ -17,9 +17,9 @@ it is added. If the value is \code{NULL}, the element is removed.}
 A modified list of elements.
 }
 \description{
-Make a new list based on \pkg{lintr}'s default linters, undesirable
-operators or functions. The result of this function is meant to be passed to
-the `linters` argument of `lint()`, or put in your configuration file.
+Make a new list based on \pkg{lintr}'s default linters, undesirable operators or functions.
+The result of this function is meant to be passed to the \code{linters} argument of \code{lint()}, or put in your
+configuration file.
 }
 \examples{
 # When using interactively you will usually pass the result onto `lint` or `lint_package()`


### PR DESCRIPTION
This is step 4 of PR https://github.com/r-lib/lintr/pull/908

- [x] `usethis::use_roxygen_md()`
- [x] Add `@seealso linters` to all relevant Rds